### PR TITLE
feat(ffi-toolkit): add response status enum for FFI

### DIFF
--- a/ffi-toolkit/src/lib.rs
+++ b/ffi-toolkit/src/lib.rs
@@ -2,6 +2,16 @@ use std::borrow::Cow;
 use std::ffi::{CStr, CString};
 use std::path::PathBuf;
 
+#[repr(C)]
+#[derive(PartialEq, Debug)]
+pub enum FCPResponseStatus {
+    // Don't use FCPSuccess, since that complicates description of 'successful' verification.
+    FCPNoError = 0,
+    FCPUnclassifiedError = 1,
+    FCPCallerError = 2,
+    FCPReceiverError = 3,
+}
+
 // produce a C string from a Rust string
 pub fn rust_str_to_c_str<T: Into<String>>(s: T) -> *mut libc::c_char {
     CString::new(s.into()).unwrap().into_raw()


### PR DESCRIPTION
The `FCPResponseStatus` enum used to be part of the sector builder. It is
now moved to ffi-toolkit so that other Filecoin FFIs can use the exact
same response status codes.

The name of the enum is kept, so that FFIs using it, will still produce
the same header files when cbindgen is used.

Part of https://github.com/filecoin-project/rust-fil-proofs-ffi/issues/8.