### PR TITLE
fix(release): move dependency out of dev

### DIFF
--- a/ffi-toolkit/Cargo.toml
+++ b/ffi-toolkit/Cargo.toml
@@ -10,6 +10,4 @@ readme = "README.md"
 
 [dependencies]
 libc = "0.2"
-
-[dev-dependencies]
 drop_struct_macro_derive = { version = "0.3", path = "../drop-struct-macro-derive" }


### PR DESCRIPTION
The `drop_struct_macro_derive` crate cannot be released in its current form:

```
08:45 $ cargo release minor
Release version drop_struct_macro_derive 0.4.0? [y/N] 
y
Update drop_struct_macro_derive to version 0.4.0
Fatal: Invalid TOML file format: error during execution of `cargo metadata`: error: failed to parse manifest at `/Users/erinswenson-healey/dev/rust/rust-fil-ffi-toolkit/ffi-toolkit/Cargo.toml`

Caused by:
  Dependency 'drop_struct_macro_derive' has different source paths depending on the build target. Each dependency must have a single canonical source path irrespective of build target.
```