### PR TITLE
chore: use --locked instead of --frozen

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
             - parameter-cache-{{ .Revision }}
       - run:
           name: Test (stable)
-          command: cargo +stable test --verbose --frozen --all
+          command: cargo +stable test --verbose --locked --all
           no_output_timeout: 15m
       - run:
           name: Prune the output files
@@ -56,10 +56,6 @@ jobs:
             for file in target/debug/* target/debug/.??*; do
               [ -d $file -o ! -x $file ] && rm -r $file
             done
-      - persist_to_workspace:
-          root: "."
-          paths:
-            - target/debug/*
 
   test_release:
     docker:
@@ -77,8 +73,8 @@ jobs:
       - run:
           name: Test (stable) in release profile
           command: |
-            cargo +stable test --verbose --release --frozen --all
-            RUSTFLAGS="-D warnings" cargo +stable build --examples --release --frozen --all
+            cargo +stable test --verbose --release --locked --all
+            RUSTFLAGS="-D warnings" cargo +stable build --examples --release --locked --all
 
   test_ignored_release:
     docker:
@@ -95,7 +91,7 @@ jobs:
             - parameter-cache-{{ .Revision }}
       - run:
           name: Test (stable) in release profile
-          command: cargo +stable test --verbose --release --frozen --all -- --ignored
+          command: cargo +stable test --verbose --release --locked --all -- --ignored
       - save_cache:
           key: parameter-cache-{{ .Revision }}
           paths:
@@ -118,7 +114,7 @@ jobs:
             - parameter-cache-{{ .Revision }}
       - run:
           name: Test (nightly)
-          command: cargo +$(cat rust-toolchain) test --verbose --frozen --all
+          command: cargo +$(cat rust-toolchain) test --verbose --locked --all
           no_output_timeout: 15m
 
   rustfmt:


### PR DESCRIPTION
`--frozen` and `--locked` are very similar. They share the idea to
use the same existing lockfile. One difference we make use of here
is, that `--locked` will also work if the Rust version used to create
the lock file is different from the one that is used to build/test
the project.

This is needed for this CI config, as the Rust version bundled with
the image is way older than the version specified in `rust-toolchain`.

Also don't persist things that are not re-used.